### PR TITLE
refactor: set base image to python 3.9.6-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.9.6
+FROM python:3.9.6-slim
 
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
# Description

A clear and concise description of what was changed and why.

**Related issue (if any):** fixes #<issue number goes here>
