### PR TITLE
ci(syntax): fix deprecated actions syntax. Fixes #566

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Get current date
         id: getDate
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Cache Docker layers
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Get current date
         id: current_date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Build images and push to DockerHub
         uses: docker/build-push-action@v4.1.1

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Get current date
         id: getDate
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Build images and push to GHCR
         uses: docker/build-push-action@v4.1.1


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->
## Description
Remove usage of `set-output` on the Github Actions Workflows

#### Describe what you did and why.
I followed the specs on the issue with the `help wanted` label

**Related issue (if any):** fixes #556

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

