### PR TITLE
docs: fixed example doc for delete_schedule

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -519,7 +519,7 @@ paths:
                 schedule:
                   type: string
             example:
-              name: "7"
+              schedule: "7"
       responses:
         "200":
           description: An empty JSON object


### PR DESCRIPTION
Fixing the body JSON example for Delete Schedule.
Updating the wrong property "name" to correct property "schedule".

<!-- markdownlint-disable MD041-->
## Description

> Describe what you did and why.
Updated the DOC, changing the "name" in the Delete Schedule example body JSON to "schedule".

## Checklist

- [X] I have followed this repository's contributing guidelines.
- [X] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
