### PR TITLE
revert: build: bump python from 3.13.1-slim to 3.14.0a4-slim (#807)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.0a4-slim
+FROM python:3.13.1-slim
 
 ARG TIMEZONE="Asia/Jerusalem"
 


### PR DESCRIPTION
This reverts commit ae8053c0fe61da309af8c847d2a0aa799ebf6e2d.
