### PR TITLE
chore: use github-actions[bot] identity and SSH signing

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+---
+reviews:
+  path_instructions:
+    - path: app/**/*.py
+      instructions: |
+        Review Python code for:
+        - Type annotations and proper typing
+        - Async/await patterns for FastAPI endpoints
+        - Docstrings following PEP 257 conventions
+        - Proper error handling and HTTP status codes
+    - path: Dockerfile
+      instructions: |
+        Review Dockerfile for:
+        - Multi-stage build efficiency
+        - Security best practices
+        - Minimal image size

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Setup SSH signing
         run: |
           mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
           echo "${{ secrets.SIGNING_KEY }}" > ~/.ssh/signing_key
           chmod 600 ~/.ssh/signing_key
           git config gpg.format ssh
@@ -153,3 +154,7 @@ jobs:
           git push
         # yamllint enable rule:line-length
         # editorconfig-checker-enable
+
+      - name: Cleanup SSH signing key
+        if: always()
+        run: rm -f ~/.ssh/signing_key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,17 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup SSH signing
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SIGNING_KEY }}" > ~/.ssh/signing_key
+          chmod 600 ~/.ssh/signing_key
+          git config gpg.format ssh
+          git config user.signingkey ~/.ssh/signing_key
+          git config commit.gpgsign true
 
       - name: Setup Python 3.13
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary

- Use `github-actions[bot]` identity for release commits instead of `github.actor`
- Add SSH commit signing using `SIGNING_KEY` secret

## Changes

- Updated git config to use bot identity (ID 41898282)
- Added SSH signing setup step

## Prerequisites

Ensure `SIGNING_KEY` secret is configured in the `deployment` environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to establish consistent quality standards.
  * Enhanced release process with improved security measures for signed releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->