### PR TITLE
chore: add sourcery configuration

### DIFF
--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,0 +1,9 @@
+# Sourcery configuration for switcher_webapi
+# https://docs.sourcery.ai/Configuration/
+---
+ignore:
+  - tests/**
+  - docs/**
+
+rule_settings:
+  python_version: "3.12"


### PR DESCRIPTION
## Summary
- Add Sourcery configuration for Python code review
- Configured to ignore tests and docs directories
- Set Python version to 3.12