### PR TITLE
fix: run container as non-root user for security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,11 @@ RUN ln -fs /usr/share/zoneinfo/$TIMEZONE /etc/localtime
 
 RUN apt-get update && apt-get -y install build-essential && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /usr/switcher_webapi
+RUN adduser --system --home /app appuser
 
-COPY LICENSE app/webapp.py requirements.txt ./
+WORKDIR /app
+
+COPY --chown=appuser:nogroup LICENSE app/webapp.py requirements.txt ./
 
 RUN pip install -U pip
 
@@ -17,6 +19,8 @@ RUN AIOHTTP_NO_EXTENSIONS=1 \
     MULTIDICT_NO_EXTENSIONS=1 \
     YARL_NO_EXTENSIONS=1 \
     pip install -r requirements.txt
+
+USER appuser
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- Create unprivileged `appuser` system user in Dockerfile
- Switch to non-root user before running the application
- Prevents potential RCE from gaining root privileges inside the container

## Test plan
- [ ] Verify Docker image builds successfully
- [ ] Verify container runs correctly as non-root user
- [ ] Verify application responds on port 8000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Container now runs with non-root user privileges. Updated file ownership and working directory configuration for improved deployment practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->