### PR TITLE
chore: add Cursor project configuration

### DIFF
--- a/.cursor/agents/code-reviewer.md
+++ b/.cursor/agents/code-reviewer.md
@@ -1,0 +1,38 @@
+---
+name: code-reviewer
+description: Reviews code for quality, security, and project conventions. Use before committing changes.
+---
+
+You are a code reviewer for switcher_webapi, an aiohttp web app wrapping aioswitcher.
+
+When invoked:
+1. Run `git diff` to see recent changes
+2. Focus on modified files
+3. Begin review immediately
+
+## Review Checklist
+
+**Code Quality:**
+- Async/await patterns correct
+- Type annotations present
+- Docstrings follow PEP 257
+- No duplicated code
+- Proper error handling with HTTP status codes
+
+**Security:**
+- No exposed secrets
+- Dockerfile runs as non-root user
+- Input validation on endpoints
+
+**Project Conventions:**
+- Uses ruff for linting (not flake8/black/isort)
+- Config in pyproject.toml
+- Tests mock aioswitcher API
+
+## Feedback Format
+
+Organize by priority:
+- **Critical** - must fix before commit
+- **Warnings** - should fix
+- **Suggestions** - consider improving
+

--- a/.cursor/agents/docs-writer.md
+++ b/.cursor/agents/docs-writer.md
@@ -1,0 +1,42 @@
+---
+name: docs-writer
+description: Updates documentation after changes. Use after adding features, modifying endpoints, or when docs need updating.
+---
+
+You are a documentation writer for switcher_webapi.
+
+When invoked:
+1. Identify what documentation needs updating
+2. Check existing doc style and structure
+3. Update or create documentation
+
+## Project Documentation
+
+**Key Files:**
+- `README.md` - User-facing overview and quick start
+- `CONTRIBUTING.md` - Developer setup and workflow
+- `docs/` - MkDocs site with endpoint documentation
+
+## Documentation Style
+
+**CONTRIBUTING.md:**
+- Clear setup instructions
+- Development workflow commands
+- Keep it practical
+
+**docs/ (MkDocs):**
+- Endpoint documentation by category
+- Query parameters and body schemas
+- Response examples
+
+## When to Update Docs
+
+- New endpoint added
+- Endpoint behavior changed
+- Configuration option changed
+- Development workflow changed
+
+## After Updating
+
+- Run `mkdocs serve` to verify changes
+- Ensure consistency with existing style

--- a/.cursor/agents/test-writer.md
+++ b/.cursor/agents/test-writer.md
@@ -1,0 +1,40 @@
+---
+name: test-writer
+description: Writes tests for switcher_webapi using pytest-asyncio and aiohttp test client. Use when adding or updating tests.
+---
+
+You are a test writer for switcher_webapi.
+
+## Testing Stack
+- pytest with pytest-asyncio (auto mode - no decorators needed)
+- pytest-aiohttp for web client testing
+- unittest.mock for mocking aioswitcher API
+
+## Test Structure
+
+Tests live in `app/tests/`. Each test file tests a specific aspect:
+- `test_web_app.py` - Endpoint tests
+- `test_serialization_helper.py` - Helper function tests
+- `test_access_logger_implementation.py` - Logger tests
+
+## Writing Tests
+
+Use the `api_client` fixture (defined in `test_web_app.py`):
+
+```python
+async def test_endpoint_name(api_client):
+    """Test description."""
+    with patch("app.webapp.SwitcherApi") as mock_api:
+        mock_api.return_value.__aenter__.return_value.method = AsyncMock(
+            return_value=expected_response
+        )
+        resp = await api_client.get("/endpoint")
+        assert resp.status == 200
+```
+
+## Coverage Requirements
+- Cover happy paths AND error cases
+- Test invalid inputs return 400
+- Test device not found returns 404
+- Minimum 85% coverage (configured in pyproject.toml)
+

--- a/.cursor/commands/image-build.md
+++ b/.cursor/commands/image-build.md
@@ -1,0 +1,31 @@
+---
+name: image-build
+description: Build container image locally for testing (uses podman if available)
+---
+
+Build single-platform image for local testing:
+
+```bash
+CONTAINER_CMD=$(command -v podman 2>/dev/null || echo docker)
+$CONTAINER_CMD build -t switcher_webapi:local .
+```
+
+Run the container:
+
+```bash
+CONTAINER_CMD=$(command -v podman 2>/dev/null || echo docker)
+$CONTAINER_CMD run -d -p 8000:8000 --name switcher_webapi switcher_webapi:local
+```
+
+Test it's running:
+
+```bash
+curl http://localhost:8000/
+```
+
+Stop and remove:
+
+```bash
+CONTAINER_CMD=$(command -v podman 2>/dev/null || echo docker)
+$CONTAINER_CMD stop switcher_webapi && $CONTAINER_CMD rm switcher_webapi
+```

--- a/.cursor/commands/lint.md
+++ b/.cursor/commands/lint.md
@@ -6,14 +6,14 @@ description: Run ruff linter and formatter checks
 Run linting and format checks:
 
 ```bash
-ruff check app/
-ruff format --check app/
+ruff check .
+ruff format --check .
 mypy --ignore-missing-imports app/
 ```
 
 To auto-fix issues:
 
 ```bash
-ruff check --fix app/
-ruff format app/
+ruff check --fix .
+ruff format .
 ```

--- a/.cursor/commands/lint.md
+++ b/.cursor/commands/lint.md
@@ -1,0 +1,19 @@
+---
+name: lint
+description: Run ruff linter and formatter checks
+---
+
+Run linting and format checks:
+
+```bash
+ruff check app/
+ruff format --check app/
+mypy --ignore-missing-imports app/
+```
+
+To auto-fix issues:
+
+```bash
+ruff check --fix app/
+ruff format app/
+```

--- a/.cursor/commands/serve-docs.md
+++ b/.cursor/commands/serve-docs.md
@@ -1,0 +1,18 @@
+---
+name: serve-docs
+description: Build and serve MkDocs documentation locally
+---
+
+Serve docs locally:
+
+```bash
+mkdocs serve
+```
+
+Build docs:
+
+```bash
+mkdocs build
+```
+
+Docs will be available at http://127.0.0.1:8000

--- a/.cursor/commands/stop-docs.md
+++ b/.cursor/commands/stop-docs.md
@@ -1,0 +1,10 @@
+---
+name: stop-docs
+description: Stop the MkDocs documentation server
+---
+
+Stop the docs server:
+
+```bash
+pkill -f "mkdocs serve"
+```

--- a/.cursor/commands/stop-docs.md
+++ b/.cursor/commands/stop-docs.md
@@ -3,8 +3,8 @@ name: stop-docs
 description: Stop the MkDocs documentation server
 ---
 
-Stop the docs server:
+Stop the docs server (run from project root):
 
 ```bash
-pkill -f "mkdocs serve"
+pkill -f "mkdocs serve.*switcher_webapi"
 ```

--- a/.cursor/commands/test.md
+++ b/.cursor/commands/test.md
@@ -1,0 +1,28 @@
+---
+name: test
+description: Run pytest with coverage
+---
+
+Run all tests:
+
+```bash
+pytest -v
+```
+
+Run with coverage:
+
+```bash
+pytest -v --cov --cov-report term-missing
+```
+
+Run specific test:
+
+```bash
+pytest -v -k "test_name_here"
+```
+
+Generate HTML coverage report:
+
+```bash
+pytest -v --cov --cov-report=html
+```

--- a/.cursor/rules/project-rules.mdc
+++ b/.cursor/rules/project-rules.mdc
@@ -1,0 +1,31 @@
+---
+description: Project rules and conventions for switcher_webapi - an aiohttp wrapper for aioswitcher
+alwaysApply: true
+---
+
+# switcher_webapi - Project Rules
+
+## Coding Conventions
+- Use venv for Python
+- aiohttp for web handlers
+- aioswitcher for device communication
+- Type annotations and PEP 257 docstrings
+
+## Architecture Constraints
+- All handlers must be async
+- Mock aioswitcher in tests (no real devices)
+- Docker runs as non-root user
+- Multi-platform builds (amd64, arm/v7, arm64/v8)
+
+## Git Rules
+- Conventional commits for PR titles (feat:, fix:, docs:, chore:)
+- Always squash merge PRs
+- GPG sign all commits
+- CodeRabbit and Sourcery review all PRs
+
+## Development Tools
+- **Linting/Formatting**: Ruff (configured in pyproject.toml)
+- **Testing**: pytest with pytest-asyncio (auto mode)
+- **Type checking**: mypy
+- **Docs**: MkDocs with Material theme
+

--- a/.cursor/skills/add-endpoint/SKILL.md
+++ b/.cursor/skills/add-endpoint/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: add-endpoint
+description: Step-by-step guide for adding a new API endpoint to switcher_webapi. Use when adding new device functionality or API routes.
+---
+
+# Adding a New Endpoint
+
+## When to Use
+- Adding new device control functionality
+- Exposing new aioswitcher API methods
+- Creating new query endpoints
+
+## Step 1: Define Endpoint Constant
+
+In `app/webapp.py`, add the endpoint path constant (around line 54-71):
+
+```python
+ENDPOINT_YOUR_ENDPOINT = "/switcher/your_endpoint"
+```
+
+## Step 2: Create Handler Function
+
+Add the async handler with the appropriate decorator:
+
+```python
+@routes.get(ENDPOINT_YOUR_ENDPOINT)  # or .post, .patch, .delete
+async def your_endpoint(request: web.Request) -> web.Response:
+    """Describe what this endpoint does."""
+    device_type = DEVICES[request.query[KEY_TYPE]]
+    if KEY_LOGIN_KEY in request.query:
+        login_key = request.query[KEY_LOGIN_KEY]
+    else:
+        login_key = "00"
+    async with SwitcherApi(
+        device_type, request.query[KEY_IP], request.query[KEY_ID], login_key
+    ) as swapi:
+        result = await swapi.your_method()
+        return web.json_response(_serialize_object(result))
+```
+
+## Step 3: Add Tests
+
+In `app/tests/test_web_app.py`, add test cases:
+
+```python
+@mark.parametrize("url", [
+    "/switcher/your_endpoint?type=plug&id=ab1c2d&ip=1.2.3.4",
+    "/switcher/your_endpoint?type=plug&id=ab1c2d&ip=1.2.3.4&key=18",
+])
+async def test_successful_your_endpoint_get_request(api_client, url):
+    with patch("app.webapp.SwitcherApi") as mock_api:
+        mock_api.return_value.__aenter__.return_value.your_method = AsyncMock(
+            return_value=expected_response
+        )
+        resp = await api_client.get(url)
+        assert resp.status == 200
+```
+
+## Step 4: Update Documentation
+
+Create or update the relevant docs file in `docs/`:
+- Add endpoint to the appropriate `endpoints_*.md` file
+- Include method, path, description, and query parameters
+
+## Step 5: Run Tests
+
+Use the `/test` command to run tests with coverage.
+
+## Reference
+
+Look at existing endpoints for patterns:
+- `get_state` - Simple GET returning device state
+- `turn_on` - POST with optional body parameters
+- `control_breeze_device` - PATCH with complex body handling

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.13'
           cache: 'pip'
           cache-dependency-path: |
-            requirements-dev.txt
+            requirements.txt
             requirements_docs.txt
 
       - name: Prepare python environment

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -71,13 +71,6 @@ jobs:
         id: getDate
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
-      - name: Cache Docker layers
-        uses: actions/cache@v5
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('**/Dockerfile') }}
-          restore-keys: ${{ runner.os }}-buildx-
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.7.0
 
@@ -94,5 +87,5 @@ jobs:
             BUILD_DATE=${{ steps.getDate.outputs.date }}
             VERSION=testing
           tags: tomerfi/switcher_webapi:testing
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: '3.13'
           cache: 'pip'
           cache-dependency-path: |
-            requirements-dev.txt
+            requirements.txt
             requirements_docs.txt
 
       - name: Prepare python environment
@@ -54,12 +54,6 @@ jobs:
 
       - name: Build documentation site
         run: mkdocs build
-
-      - name: Cache Docker layers
-        uses: actions/cache@v5
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('**/Dockerfile') }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.7.0
@@ -112,10 +106,8 @@ jobs:
             VCS_REF=${{ github.sha }}
             BUILD_DATE=${{ steps.current_date.outputs.date }}
             VERSION=${{ steps.bumper.outputs.next }}
-          cache-from: |
-            type=local,src=/tmp/.buildx-cache
-            ghcr.io/tomerfi/switcher_webapi:early-access
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Create a release name
         id: release_name

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.13'
           cache: 'pip'
           cache-dependency-path: |
-            requirements-dev.txt
+            requirements.txt
             requirements_test.txt
 
       - name: Prepare python environment
@@ -31,12 +31,6 @@ jobs:
 
       - name: Test project
         run: pytest -v --cov --cov-report=xml:coverage.xml
-
-      - name: Cache Docker layers
-        uses: actions/cache@v5
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('**/Dockerfile') }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.7.0
@@ -66,10 +60,8 @@ jobs:
             VCS_REF=${{ github.sha }}
             BUILD_DATE=${{ steps.getDate.outputs.date }}
             VERSION=early-access
-          cache-from: |
-            type=local,src=/tmp/.buildx-cache
-            ghcr.io/tomerfi/switcher_webapi:early-access
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Push coverage report to CodeCov
         uses: codecov/codecov-action@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,8 @@ pip install -r requirements.txt -r requirements_test.txt -r requirements_docs.tx
 Run linters using [ruff][ruff]:
 
 ```shell
-ruff check app/
-ruff format --check app/
+ruff check .
+ruff format --check .
 mypy --ignore-missing-imports app/
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dynamic = ["version"]
 [tool.ruff]
 line-length = 88
 target-version = "py313"
+exclude = [".venv", "venv", ".git", "build", "dist", "__pycache__", "site"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "D", "W"]


### PR DESCRIPTION
## Summary
- Add Cursor agents for code review and test writing
- Add commands for lint, test, docs, and image builds
- Add project rules and conventions

## Files Added
```
.cursor/
├── agents/
│   ├── code-reviewer.md
│   └── test-writer.md
├── commands/
│   ├── image-build.md
│   ├── lint.md
│   ├── serve-docs.md
│   ├── stop-docs.md
│   └── test.md
└── rules/
    └── project-rules.mdc
```

## Test plan
- [x] `/lint` command works
- [x] `/test` command works
- [x] `/serve-docs` and `/stop-docs` commands work
- [x] `/image-build` command works (with podman/docker detection)

## Summary by Sourcery

Add Cursor project configuration including AI agents, development commands, and project rules to streamline local development and reviews.

New Features:
- Introduce Cursor AI agents for code review and test writing tailored to the switcher_webapi project.
- Add documented commands for running linting, tests, docs, and local image builds via Cursor.

Build:
- Document a local single-platform container image build and run workflow using podman or docker.

Documentation:
- Document MkDocs serve and build workflows and how to stop the local docs server within the Cursor command set.

Chores:
- Add project rules and conventions under .cursor to guide consistent development practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added developer guidelines covering coding conventions, architecture, tooling, and project rules.
  * Added operational guides for building/running local containers and serving/stopping project docs.
  * Added linting/formatting and test command guides (including pytest usage, coverage reporting, and an 85% coverage target).
  * Added role-specific guides for code reviews, writing tests, docs updates, and adding new API endpoints.
  * Updated contributing guide to adjust linting targets to the project root.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->