### PR TITLE
feat: add health endpoint and E2E smoke test in CI

### DIFF
--- a/.cursor/agents/docs-writer.md
+++ b/.cursor/agents/docs-writer.md
@@ -14,8 +14,9 @@ When invoked:
 
 **Key Files:**
 - `README.md` - User-facing overview and quick start
-- `CONTRIBUTING.md` - Developer setup and workflow
+- `CONTRIBUTING.md` - Developer setup, workflow, and Cursor IDE agents/commands
 - `docs/` - MkDocs site with endpoint documentation
+- `.cursor/` - Cursor agents, commands, rules, and skills (self-documenting)
 
 ## Documentation Style
 

--- a/.cursor/agents/smoke-tester.md
+++ b/.cursor/agents/smoke-tester.md
@@ -1,0 +1,43 @@
+---
+name: smoke-tester
+description: Runs E2E smoke tests on the container image. Use to verify the image runs and responds to health checks.
+---
+
+You are a smoke tester for switcher_webapi container images.
+
+When invoked:
+1. Use the `/image-build` command to build the container image
+2. Run the container
+3. Test the /health endpoint
+4. Report results and cleanup
+
+## Steps
+
+First, run `/image-build` to build the image.
+
+Then run and test:
+
+```bash
+CONTAINER_CMD=$(command -v podman 2>/dev/null || echo docker)
+$CONTAINER_CMD run -d --name smoke-test -p 8000:8000 switcher_webapi:local
+sleep 5
+curl -sf http://localhost:8000/health && echo "Health check passed" || echo "Health check FAILED"
+$CONTAINER_CMD logs smoke-test
+$CONTAINER_CMD stop smoke-test
+$CONTAINER_CMD rm smoke-test
+```
+
+## Expected Output
+
+The /health endpoint should return:
+```json
+{"status": "healthy"}
+```
+
+## Troubleshooting
+
+If health check fails:
+- Check container logs for startup errors
+- Verify port 8000 is not in use
+- Ensure webapp.py has the health endpoint defined
+

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -112,8 +112,11 @@ jobs:
       - name: Run container and test health endpoint
         run: |
           docker run -d --name test-container -p 8000:8000 switcher_webapi:test
-          sleep 5
-          response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/health)
+          for i in {1..12}; do
+            response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/health || true)
+            [ "$response" = "200" ] && break
+            sleep 5
+          done
           docker logs test-container
           docker stop test-container
           if [ "$response" != "200" ]; then

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -89,3 +89,35 @@ jobs:
           tags: tomerfi/switcher_webapi:testing
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  e2e-smoke-test:
+    runs-on: ubuntu-latest
+    name: E2E smoke test
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.12.0
+
+      - name: Build image for testing
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          load: true
+          tags: switcher_webapi:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run container and test health endpoint
+        run: |
+          docker run -d --name test-container -p 8000:8000 switcher_webapi:test
+          sleep 5
+          response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/health)
+          docker logs test-container
+          docker stop test-container
+          if [ "$response" != "200" ]; then
+            echo "Health check failed with status $response"
+            exit 1
+          fi
+          echo "Health check passed with status $response"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,27 @@ mkdocs build
 mkdocs serve
 ```
 
+### Cursor IDE
+
+If using [Cursor][cursor], agents and commands are available in `.cursor/`:
+
+**Agents:**
+
+- `code-reviewer` - Reviews code before committing
+- `test-writer` - Writes tests using pytest-asyncio
+- `docs-writer` - Updates documentation
+- `smoke-tester` - Runs E2E smoke tests on the container
+
+**Commands:**
+
+- `/lint` - Run linting checks
+- `/test` - Run tests
+- `/serve-docs` - Serve docs locally
+- `/stop-docs` - Stop docs server
+- `/image-build` - Build container image
+
 <!-- LINKS -->
+[cursor]: https://cursor.sh/
 [docker]: https://www.docker.com/
 [docker_hub]: https://hub.docker.com/r/tomerfi/switcher_webapi
 [ghcr]: https://github.com/TomerFi/switcher_webapi/pkgs/container/switcher_webapi

--- a/app/tests/test_web_app.py
+++ b/app/tests/test_web_app.py
@@ -139,6 +139,13 @@ def response_mock():
     return Mock()
 
 
+async def test_health_endpoint_returns_healthy_status(api_client):
+    resp = await api_client.get(webapp.ENDPOINT_HEALTH)
+    assert_that(resp.status).is_equal_to(200)
+    body = await resp.json()
+    assert_that(body).is_equal_to({"status": "healthy"})
+
+
 @mark.parametrize(
     "api_uri",
     [

--- a/app/tests/test_web_app.py
+++ b/app/tests/test_web_app.py
@@ -142,6 +142,7 @@ def response_mock():
 async def test_health_endpoint_returns_healthy_status(api_client):
     resp = await api_client.get(webapp.ENDPOINT_HEALTH)
     assert_that(resp.status).is_equal_to(200)
+    assert_that(resp.content_type).is_equal_to("application/json")
     body = await resp.json()
     assert_that(body).is_equal_to({"status": "healthy"})
 

--- a/app/webapp.py
+++ b/app/webapp.py
@@ -51,6 +51,7 @@ KEY_THERMOSTAT_SWING = "thermostat_swing"
 KEY_CURRENT_DEVICE_STATE = "current_device_state"
 KEY_REMOTE_ID = "remote_id"
 
+ENDPOINT_HEALTH = "/health"
 ENDPOINT_GET_STATE = "/switcher/get_state"
 ENDPOINT_TURN_ON = "/switcher/turn_on"
 ENDPOINT_TURN_OFF = "/switcher/turn_off"
@@ -124,6 +125,12 @@ def _serialize_object(obj: object) -> Dict[str, Union[List[str], str]]:
             else:
                 serialized_dict[k] = v
     return serialized_dict
+
+
+@routes.get(ENDPOINT_HEALTH)
+async def health(request: web.Request) -> web.Response:
+    """Health check endpoint for container orchestration."""
+    return web.json_response({"status": "healthy"})
 
 
 @routes.get(ENDPOINT_GET_STATE)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,4 +20,15 @@ docker run -d -p 8000:8000 --name switcher_webapi tomerfi/switcher_webapi:latest
 ???- warning "Since version 2.x.x, all endpoints require a device type query param."
     --8<-- "device_types.md"
 
+## Health Check
+
+=== ":material-check-circle: GET /health"
+
+    Health check endpoint for container orchestration (e.g., Kubernetes liveness probes).
+    Returns `{"status": "healthy"}` with HTTP 200.
+
+    ```shell
+    curl http://localhost:8000/health
+    ```
+
 --8<-- "endpoints_all.md"


### PR DESCRIPTION
## Summary
- Add `/health` endpoint for container orchestration health checks (returns `{"status": "healthy"}`)
- Add E2E smoke test job in PR workflow that builds the container and tests the health endpoint
- Add `smoke-tester` Cursor agent for local smoke testing
- Document health endpoint in mkdocs site

## Test plan
- [x] Unit test for health endpoint passes
- [x] All 66 tests pass with 96% coverage
- [x] Local container smoke test passes
- [x] CI E2E smoke test job passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added health check endpoint for container orchestration systems like Kubernetes
  * Integrated automated E2E smoke testing into the CI pipeline

* **Documentation**
  * Extended developer documentation with health endpoint specifications and usage examples
  * Added guidance for available development tools and workflow enhancements

* **Tests**
  * Added automated tests validating health endpoint response

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->