### PR TITLE
chore: fix Cursor config and add dockerfile-lint command

### DIFF
--- a/.cursor/agents/code-reviewer.md
+++ b/.cursor/agents/code-reviewer.md
@@ -21,7 +21,7 @@ When invoked:
 
 **Security:**
 - No exposed secrets
-- Dockerfile runs as non-root user
+- Dockerfile should run as non-root user (pending fix)
 - Input validation on endpoints
 
 **Project Conventions:**

--- a/.cursor/agents/smoke-tester.md
+++ b/.cursor/agents/smoke-tester.md
@@ -23,9 +23,14 @@ $CONTAINER_CMD run -d --name smoke-test -p 8000:8000 switcher_webapi:local
 for i in {1..12}; do
   response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/health || true)
   [ "$response" = "200" ] && break
+  echo "Attempt $i: status $response, retrying in 5s..."
   sleep 5
 done
-[ "$response" = "200" ] && echo "Health check passed" || echo "Health check FAILED"
+if [ "$response" = "200" ]; then
+  echo "Health check passed"
+else
+  echo "Health check FAILED after 12 attempts (60s timeout)"
+fi
 $CONTAINER_CMD logs smoke-test
 $CONTAINER_CMD stop smoke-test
 $CONTAINER_CMD rm smoke-test

--- a/.cursor/agents/smoke-tester.md
+++ b/.cursor/agents/smoke-tester.md
@@ -20,8 +20,12 @@ Then run and test:
 ```bash
 CONTAINER_CMD=$(command -v podman 2>/dev/null || echo docker)
 $CONTAINER_CMD run -d --name smoke-test -p 8000:8000 switcher_webapi:local
-sleep 5
-curl -sf http://localhost:8000/health && echo "Health check passed" || echo "Health check FAILED"
+for i in {1..12}; do
+  response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/health || true)
+  [ "$response" = "200" ] && break
+  sleep 5
+done
+[ "$response" = "200" ] && echo "Health check passed" || echo "Health check FAILED"
 $CONTAINER_CMD logs smoke-test
 $CONTAINER_CMD stop smoke-test
 $CONTAINER_CMD rm smoke-test

--- a/.cursor/commands/dockerfile-lint.md
+++ b/.cursor/commands/dockerfile-lint.md
@@ -7,7 +7,7 @@ Run hadolint on Dockerfile:
 
 ```bash
 CONTAINER_CMD=$(command -v podman 2>/dev/null || echo docker)
-$CONTAINER_CMD run --rm -i hadolint/hadolint < Dockerfile
+$CONTAINER_CMD run --rm -i hadolint/hadolint:v2.14.0 < Dockerfile
 ```
 
 Or if hadolint is installed locally:

--- a/.cursor/commands/dockerfile-lint.md
+++ b/.cursor/commands/dockerfile-lint.md
@@ -1,0 +1,19 @@
+---
+name: dockerfile-lint
+description: Lint Dockerfile with hadolint
+---
+
+Run hadolint on Dockerfile:
+
+```bash
+CONTAINER_CMD=$(command -v podman 2>/dev/null || echo docker)
+$CONTAINER_CMD run --rm -i hadolint/hadolint < Dockerfile
+```
+
+Or if hadolint is installed locally:
+
+```bash
+hadolint Dockerfile
+```
+
+Note: Some warnings are expected until security fixes are applied (e.g., DL3002 for non-root user).

--- a/.cursor/commands/image-build.md
+++ b/.cursor/commands/image-build.md
@@ -20,7 +20,7 @@ $CONTAINER_CMD run -d -p 8000:8000 --name switcher_webapi switcher_webapi:local
 Test it's running:
 
 ```bash
-curl http://localhost:8000/
+curl http://localhost:8000/health
 ```
 
 Stop and remove:

--- a/.cursor/rules/project-rules.mdc
+++ b/.cursor/rules/project-rules.mdc
@@ -14,14 +14,14 @@ alwaysApply: true
 ## Architecture Constraints
 - All handlers must be async
 - Mock aioswitcher in tests (no real devices)
-- Docker runs as non-root user
+- Docker should run as non-root user (pending)
 - Multi-platform builds (amd64, arm/v7, arm64/v8)
 
 ## Git Rules
 - Conventional commits for PR titles (feat:, fix:, docs:, chore:)
 - Always squash merge PRs
 - GPG sign all commits
-- CodeRabbit and Sourcery review all PRs
+- Address CodeRabbit and Sourcery comments before merging
 
 ## Development Tools
 - **Linting/Formatting**: Ruff (configured in pyproject.toml)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,7 @@ If using [Cursor][cursor], agents and commands are available in `.cursor/`:
 - `/serve-docs` - Serve docs locally
 - `/stop-docs` - Stop docs server
 - `/image-build` - Build container image
+- `/dockerfile-lint` - Lint Dockerfile with hadolint
 
 <!-- LINKS -->
 [cursor]: https://cursor.sh/


### PR DESCRIPTION
## Summary
- Fix non-root user claims to say "(pending)" in rules and code-reviewer agent
- Update health endpoint URL from `/` to `/health` in image-build command
- Improve CodeRabbit/Sourcery rule to be actionable
- Add retry loop to smoke-tester agent (consistency with CI)
- Add `dockerfile-lint` command for hadolint
- Update CONTRIBUTING.md with new command

## Test plan
- [x] smoke-tester agent passes
- [x] code-reviewer agent finds no issues
- [x] dockerfile-lint command works

## Summary by Sourcery

Align Cursor agent and command docs with current container behavior and add support for linting Dockerfiles with hadolint.

New Features:
- Add a dockerfile-lint Cursor command for running hadolint against the Dockerfile.

Enhancements:
- Update smoke-tester agent to retry the health check endpoint before failing.
- Adjust image-build command docs to use the /health endpoint for container health verification.
- Clarify code-reviewer agent expectations around running Docker images as non-root, marking it as a pending fix.
- Document the new /dockerfile-lint command in CONTRIBUTING guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `/dockerfile-lint` command for linting Dockerfiles with hadolint.

* **Improvements**
  * Health check now retries (up to 12 attempts, 5s interval) and uses the /health endpoint for reliability and clearer reporting.

* **Documentation**
  * Updated Docker security wording and PR review workflow guidance.
  * Added Dockerfile linting documentation with usage instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->