### PR TITLE
chore: remove email from code of conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -53,7 +53,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team via GitHub. All complaints will
+reported by messaging the project maintainers directly via their GitHub profiles. All complaints will
 be reviewed and investigated and will result in a response that is deemed
 necessary and appropriate to the circumstances. The project team is obligated
 to maintain confidentiality with regard to the reporter of an incident.

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -53,7 +53,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at tomer@figenblat.com. All complaints will
+reported by contacting the project team via GitHub. All complaints will
 be reviewed and investigated and will result in a response that is deemed
 necessary and appropriate to the circumstances. The project team is obligated
 to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
Remove email address from Code of Conduct Enforcement section, replacing with "via GitHub" for consistency across projects.

- [x] Change applied
- [x] Verified consistency

## Summary by Sourcery

Documentation:
- Clarify the enforcement contact instructions in the Code of Conduct by directing users to contact the project team via GitHub rather than email.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Code of Conduct reporting method to direct complaints via GitHub profiles instead of a direct email; existing statements about review, confidentiality and complaint handling remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->