### PR TITLE
fix: run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,11 @@ RUN AIOHTTP_NO_EXTENSIONS=1 \
     YARL_NO_EXTENSIONS=1 \
     pip install -r requirements.txt
 
+RUN adduser --system --no-create-home appuser \
+    && chown -R appuser /usr/switcher_webapi
+
+USER appuser
+
 EXPOSE 8000
 
 ENV LOG_LEVEL=INFO


### PR DESCRIPTION
## Summary
- Fix potential RCE privilege escalation by running the container as a non-root user, as recommended by Sourcery AI.
- Add a dedicated `appuser` system user and `chown` the workdir to it.
- Set `USER appuser` before `EXPOSE`/`CMD` so the application runs unprivileged.
- Port 8000 is unprivileged, so no capability adjustments are needed.

## Validation
- `actionlint` passes (no workflow changes).
- Dockerfile change is minimal — CI will validate the multi-platform build.
