### PR TITLE
ci: security hardening for GitHub Actions workflows

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   deploy-pages:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,8 @@ jobs:
   deploy-pages:
     runs-on: ubuntu-latest
     environment: github-pages
+    permissions:
+      pages: write
     if: ${{ github.ref != 'refs/tags/early-access' }}
     name: Build documentation site and deploy to GH-Pages
     steps:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - name: Setup Python 3.13
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 
 concurrency:
-  group: ${{workflow}}-${{github.ref}}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: github-pages
     permissions:
-      pages: write
+      contents: write
     if: ${{ github.ref != 'refs/tags/early-access' }}
     name: Build documentation site and deploy to GH-Pages
     steps:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,12 +13,12 @@ jobs:
     name: Build documentation site and deploy to GH-Pages
     steps:
       - name: Source checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.ref }}
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
           cache: 'pip'
@@ -34,7 +34,7 @@ jobs:
         run: mkdocs build
 
       - name: Deploy to GH-Pages
-        uses: peaceiris/actions-gh-pages@v4.0.0
+        uses: peaceiris/actions-gh-pages@47f197a2200bb9de68ba5f48fad1c088eb1c4a32 # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Python 3.13
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -71,6 +73,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Get current date
         id: getDate
@@ -101,6 +104,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build project
     permissions:
+      contents: read
       checks: write
       pull-requests: write
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,9 +10,6 @@ concurrency:
   group: ${{workflow}}-${{github.ref}}-${{github.event.number}}
   cancel-in-progress: true
 
-permissions:
-  content: read
-
 jobs:
   build-app:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,9 @@ on:
 #    branches:
 #      - dev
 
+permissions:
+  content: read
+
 jobs:
   build-app:
     runs-on: ubuntu-latest
@@ -59,8 +62,6 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     name: Build docker
-    permissions:
-      pull-requests: read
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,10 @@ on:
 #    branches:
 #      - dev
 
+concurrency:
+  group: ${{workflow}}-${{github.ref}}-${{github.event.number}}
+  cancel-in-progress: true
+
 permissions:
   content: read
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,6 +72,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Hadolint Dockerfile
+        id: hadolint
+        uses: hadolint/hadolint-action@3fc49fb50d59c6ab7917a2e4195dba633e515b29 # v3.2.0
+        with:
+          dockerfile: Dockerfile
+
       - name: Get current date
         id: getDate
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
@@ -96,6 +102,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   e2e-smoke-test:
+    needs: build-docker
     runs-on: ubuntu-latest
     name: E2E smoke test
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
 #      - dev
 
 concurrency:
-  group: ${{workflow}}-${{github.ref}}-${{github.event.number}}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,15 +15,15 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
 
       - name: Cache pip repository
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements_test.txt') }}
@@ -43,7 +43,7 @@ jobs:
         run: pytest -v --cov --cov-report=xml:coverage.xml --junit-xml junit.xml
 
       - name: Report test summary
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@2ceeed2b8f26e15b06c3846719f75354febd9e7b # v2
         if: always()
         with:
           test_changes_limit: 0
@@ -51,7 +51,7 @@ jobs:
           report_individual_runs: true
 
       - name: Push to CodeCov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
@@ -63,7 +63,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -72,13 +72,13 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.0.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.0.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build docker image (no push)
-        uses: docker/build-push-action@v7.1.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
@@ -95,13 +95,13 @@ jobs:
     name: E2E smoke test
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.0.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build image for testing
-        uses: docker/build-push-action@v7.1.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           load: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,12 @@ jobs:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
+      - name: Hadolint Dockerfile
+        id: hadolint
+        uses: hadolint/hadolint-action@3fc49fb50d59c6ab7917a2e4195dba633e515b29 # v3.2.0
+        with:
+          dockerfile: Dockerfile
+
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
         default: "auto"
         required: true
 
+concurrency:
+  group: ${{workflow}}-${{github.ref}}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,11 @@ jobs:
 
       - name: Setup SSH signing
         run: |
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          echo "${{ secrets.SIGNING_KEY }}" > ~/.ssh/signing_key
-          chmod 600 ~/.ssh/signing_key
+          mkdir -p $RUNNER_TEMP
+          echo "${{ secrets.SIGNING_KEY }}" > $RUNNER_TEMP/signing_key
+          chmod 600 $RUNNER_TEMP/signing_key
           git config gpg.format ssh
-          git config user.signingkey ~/.ssh/signing_key
+          git config user.signingkey $RUNNER_TEMP/signing_key
           git config commit.gpgsign true
 
       - name: Setup Python 3.13
@@ -164,6 +163,3 @@ jobs:
         # yamllint enable rule:line-length
         # editorconfig-checker-enable
 
-      - name: Cleanup SSH signing key
-        if: always()
-        run: rm -f ~/.ssh/signing_key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{workflow}}-${{github.ref}}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
     name: Build, publish, release, and announce
     permissions:
       contents: write
-      packages: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build, publish, release, and announce
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
@@ -40,7 +40,7 @@ jobs:
           git config commit.gpgsign true
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
           cache: 'pip'
@@ -56,20 +56,20 @@ jobs:
         run: mkdocs build
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.0.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.0.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Determine next SemVer
         id: bumper
-        uses: tomerfi/version-bumper-action@2.0.7
+        uses: tomerfi/version-bumper-action@6892021917fa099d2986fcbf3acc584659af193a # 2.0.7
         with:
           bump: '${{ github.event.inputs.bump }}'
 
@@ -98,7 +98,7 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Build images and push to DockerHub
-        uses: docker/build-push-action@v7.1.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true
@@ -115,7 +115,7 @@ jobs:
 
       - name: Create a release name
         id: release_name
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           NEXT_VERSION: ${{ steps.bumper.outputs.next }}
           INPUT_TITLE: ${{ github.event.inputs.title }}
@@ -129,7 +129,7 @@ jobs:
 
       - name: Create a release
         id: gh_release
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           NEXT_VERSION: ${{ steps.bumper.outputs.next }}
           RELEASE_NAME: ${{ steps.release_name.outputs.value }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: deployment
     name: Build, publish, release, and announce
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - dev
 
+concurrency:
+  group: ${{workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   stage:
     runs-on: ubuntu-latest

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -14,10 +14,10 @@ jobs:
     name: Build and publish early access to GitHub
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
           cache: 'pip'
@@ -33,13 +33,13 @@ jobs:
         run: pytest -v --cov --cov-report=xml:coverage.xml
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.0.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.0.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to GHCR
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -50,7 +50,7 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Build images and push to GHCR
-        uses: docker/build-push-action@v7.1.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true
@@ -64,7 +64,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Push coverage report to CodeCov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     name: Build and publish early access to GitHub
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -8,7 +8,7 @@ on:
       - dev
 
 concurrency:
-  group: ${{workflow}}-${{github.ref}}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Python 3.13
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Hadolint Dockerfile
+        id: hadolint
+        uses: hadolint/hadolint-action@3fc49fb50d59c6ab7917a2e4195dba633e515b29 # v3.2.0
+        with:
+          dockerfile: Dockerfile
+
       - name: Setup Python 3.13
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,6 @@
+---
+troubleshoot: false
+ignored:
+  - DL3008
+  - DL3013
+  - DL3059

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,19 @@ ARG TIMEZONE="Asia/Jerusalem"
 
 RUN ln -fs /usr/share/zoneinfo/$TIMEZONE /etc/localtime
 
-RUN apt-get update && apt-get -y install build-essential && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get -y --no-install-recommends install build-essential && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/switcher_webapi
 
 COPY LICENSE app/webapp.py requirements.txt ./
 
-RUN pip install -U pip
+RUN pip install --no-cache-dir -U pip
 
 RUN AIOHTTP_NO_EXTENSIONS=1 \
     FROZENLIST_NO_EXTENSIONS=1 \
     MULTIDICT_NO_EXTENSIONS=1 \
     YARL_NO_EXTENSIONS=1 \
-    pip install -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt
 
 RUN adduser --system --no-create-home appuser \
     && chown -R appuser /usr/switcher_webapi


### PR DESCRIPTION
## Summary
- Pin all 34 GitHub Actions to SHA digests with version comments (supply-chain mitigation)
- Add `permissions:` blocks following least-privilege principle across all 4 workflows
- Move SSH signing key to `$RUNNER_TEMP/` and remove unnecessary cleanup step
- Add `concurrency:` blocks to cancel overlapping workflow runs
- Add `persist-credentials: false` to checkout steps (remove saved token from disk)
- Add hadolint Dockerfile linting to pr/stage/release workflows
- Require `build-docker` as dependency for `e2e-smoke-test` (skip smoke test if hadolint/Docker build fails)
- Fix permissions typo (`content` -> `contents` in pr.yml)

## Files Changed
- `.github/workflows/pr.yml`
- `.github/workflows/release.yml`
- `.github/workflows/stage.yml`
- `.github/workflows/pages.yml`
- `Dockerfile`
- `.hadolint.yaml` (new)

## Changes
130 insertions, 23 deletions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD: Added concurrency control to workflows to reduce overlapping runs and improve reliability.
  * CI/CD: Pinned third‑party workflow actions to specific revisions for more stable, reproducible runs.
  * CI/CD: Hardened build steps (reduced credential persistence and adjusted signing key handling) for safer releases.
  * Docker: Streamlined image build with leaner package installs and pip upgrade for more efficient builds.
  * Linting: Added/updated Hadolint configuration and container linting step to enforce image quality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TomerFi/switcher_webapi/pull/993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->