### PR TITLE
fix: add --locked to uv export in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN AIOHTTP_NO_EXTENSIONS=1 \
     FROZENLIST_NO_EXTENSIONS=1 \
     MULTIDICT_NO_EXTENSIONS=1 \
     YARL_NO_EXTENSIONS=1 \
-    uv export --no-dev > /tmp/req.txt && \
+    uv export --no-dev --locked > /tmp/req.txt && \
     pip install --no-cache-dir -r /tmp/req.txt
 
 RUN adduser --system --no-create-home appuser \


### PR DESCRIPTION
Adds `--locked` to `uv export` in the Dockerfile so it reads directly from `uv.lock` (~0.95ms) instead of re-resolving dependencies on every build.

This keeps the deterministic install from PR #1044 while avoiding the slow resolution step during container builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container builds by ensuring dependencies are installed from the locked versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->