### PR TITLE
fix: include uv.lock in release workflow commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
         env:
           NEXT_VERSION: '${{ steps.uv_new.outputs.version }}'
         run: |
-          git add pyproject.toml mkdocs.yml
+          git add pyproject.toml mkdocs.yml uv.lock
           git commit -m "build: bump version to $NEXT_VERSION [skip ci]"
           git push
 
@@ -172,6 +172,6 @@ jobs:
         env:
           DEV_VERSION: '${{ steps.uv_dev.outputs.version }}'
         run: |
-          git add pyproject.toml
+          git add pyproject.toml uv.lock
           git commit -m "build: bump version to $DEV_VERSION [skip ci]"
           git push

--- a/uv.lock
+++ b/uv.lock
@@ -1088,7 +1088,7 @@ wheels = [
 
 [[package]]
 name = "switcher-webapi"
-version = "2.5.3.dev0"
+version = "2.5.4.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The pages workflow (GH-Pages deploy) fails on release tags with:
```
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

## Root cause

`uv version --bump` updates both `pyproject.toml` and `uv.lock` — uv bakes the project version into the lockfile. However, the release workflow only committed `pyproject.toml` and `mkdocs.yml`, discarding the lockfile update. The release tag therefore has a stale lockfile that doesn't match pyproject.toml.

## Fix

Add `uv.lock` to both `git add` commands in the release workflow:

1. **Line 111** (release version bump): `pyproject.toml` → `mkdocs.yml` → `uv.lock`
2. **Line 175** (dev version bump): `pyproject.toml` → `uv.lock`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release updates now include the project’s lock file alongside version changes, helping keep published and development releases consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->