### PR TITLE
fix: share docker cache across all workflows using explicit cache key

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,8 +97,8 @@ jobs:
             BUILD_DATE=${{ steps.getDate.outputs.date }}
             VERSION=testing
           tags: tomerfi/switcher_webapi:testing
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,key=switcher-webapi-cache
+          cache-to: type=gha,key=switcher-webapi-cache,mode=max
 
   e2e-smoke-test:
     needs: build-docker
@@ -119,8 +119,8 @@ jobs:
           context: .
           load: true
           tags: switcher_webapi:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,key=switcher-webapi-cache
+          cache-to: type=gha,key=switcher-webapi-cache,mode=max
 
       - name: Run container and test health endpoint
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,8 +129,8 @@ jobs:
             VCS_REF=${{ github.sha }}
             BUILD_DATE=${{ steps.current_date.outputs.date }}
             VERSION=${{ steps.bumper.outputs.next }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,key=switcher-webapi-cache
+          cache-to: type=gha,key=switcher-webapi-cache,mode=max
 
       - name: Create a release name
         id: release_name

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -73,8 +73,8 @@ jobs:
             VCS_REF=${{ github.sha }}
             BUILD_DATE=${{ steps.getDate.outputs.date }}
             VERSION=early-access
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,key=switcher-webapi-cache
+          cache-to: type=gha,key=switcher-webapi-cache,mode=max
 
       - name: Push coverage report to CodeCov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0


### PR DESCRIPTION
## Problem

Docker builds take forever for every PR and every staging image — no cache hits.

## Root cause

`type=gha` uses a ref-scoped cache by default. Each PR gets its own cache, so builds always start from scratch. Only dev pushes shared cache (but even then, the first build of a new dependency was slow).

## Fix

Add explicit shared cache key `switcher-webapi-cache` to all three workflows:

- **pr.yml** (2 jobs) — `cache-from`/`cache-to` with key
- **stage.yml** (1 job) — same key
- **release.yml** (1 job) — same key

Now all workflows share the same Docker build cache regardless of branch or PR ref.

## What it saves

The dependency install layer (`uv export` + `pip install`) is the slowest part — pulling cached layers for it should reduce build times from ~6min to seconds once the cache is populated.