### PR TITLE
ci: removed signing key logic from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,15 +50,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Setup SSH signing
-        run: |
-          mkdir -p "$RUNNER_TEMP"
-          echo "${{ secrets.SIGNING_KEY }}" > "$RUNNER_TEMP/signing_key"
-          chmod 600 "$RUNNER_TEMP/signing_key"
-          git config gpg.format ssh
-          git config user.signingkey "$RUNNER_TEMP/signing_key"
-          git config commit.gpgsign true
-
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the release process by removing unnecessary commit-signing setup.
  * Release automation continues without generating or configuring SSH signing credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->