### PR TITLE
chore: pin all dependencies to exact versions (==)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,20 +12,20 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "assertpy>=1.1",
-    "ty>=0.0.72",
-    "prek>=0.4.13",
-    "pytest>=9.1.1",
-    "pytest-aiohttp>=1.1.1",
-    "pytest-asyncio>=1.4.0",
-    "pytest-cov>=7.1.0",
-    "pytest-sugar>=1.1.1",
-    "ruff>=0.16.3",
+    "assertpy==1.1",
+    "ty==0.0.75",
+    "prek==0.4.14",
+    "pytest==9.1.1",
+    "pytest-aiohttp==1.1.1",
+    "pytest-asyncio==1.4.0",
+    "pytest-cov==7.1.0",
+    "pytest-sugar==1.1.1",
+    "ruff==0.16.4",
 ]
 docs = [
-    "mkdocs>=1.6.1",
-    "mkdocs-git-revision-date-plugin>=0.3.2",
-    "mkdocs-material>=9.7.7",
+    "mkdocs==1.6.1",
+    "mkdocs-git-revision-date-plugin==0.3.2",
+    "mkdocs-material==9.7.7",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -1112,20 +1112,20 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "assertpy", specifier = ">=1.1" },
-    { name = "prek", specifier = ">=0.4.13" },
-    { name = "pytest", specifier = ">=9.1.1" },
-    { name = "pytest-aiohttp", specifier = ">=1.1.1" },
-    { name = "pytest-asyncio", specifier = ">=1.4.0" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-sugar", specifier = ">=1.1.1" },
-    { name = "ruff", specifier = ">=0.16.3" },
-    { name = "ty", specifier = ">=0.0.72" },
+    { name = "assertpy", specifier = "==1.1" },
+    { name = "prek", specifier = "==0.4.14" },
+    { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-aiohttp", specifier = "==1.1.1" },
+    { name = "pytest-asyncio", specifier = "==1.4.0" },
+    { name = "pytest-cov", specifier = "==7.1.0" },
+    { name = "pytest-sugar", specifier = "==1.1.1" },
+    { name = "ruff", specifier = "==0.16.4" },
+    { name = "ty", specifier = "==0.0.75" },
 ]
 docs = [
-    { name = "mkdocs", specifier = ">=1.6.1" },
-    { name = "mkdocs-git-revision-date-plugin", specifier = ">=0.3.2" },
-    { name = "mkdocs-material", specifier = ">=9.7.7" },
+    { name = "mkdocs", specifier = "==1.6.1" },
+    { name = "mkdocs-git-revision-date-plugin", specifier = "==0.3.2" },
+    { name = "mkdocs-material", specifier = "==9.7.7" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace `>=` version declarations with `==` matching resolved versions in `uv.lock`.

### Changes
- 12 dependencies converted from `>=x.y.z` to `==x.y.z`
- 3 packages were already pinned (`aioswitcher`, `aiohttp`, `mkdocs-get-deps`)
- `uv.lock` updated to reflect exact version pins

### Why
With `>=` declarations, Dependabot only updates the lock file in PRs without actual version changes. Using `==` pins ensures Dependabot creates meaningful update PRs whenever new versions are available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development and documentation tooling versions.
  * Standardized development and documentation dependencies to fixed versions for more consistent project maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->